### PR TITLE
feat: player can win card FE

### DIFF
--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,2 +1,4 @@
 export * from "./button"
 export * from "./card"
+export * from "./card-empty-state"
+export * from "./player-card"

--- a/frontend/src/components/player-card.tsx
+++ b/frontend/src/components/player-card.tsx
@@ -6,11 +6,12 @@ import { theme } from "../theme"
 import { Card } from "./card"
 import { CardEmptyState } from "./card-empty-state"
 
-interface IPlayerCardProps {
+export interface IPlayerCardProps {
   card: IPlayingCard | null
   playerName: string
   isCurrentPlayerTurn: boolean
   isOpponent?: boolean
+  onClick?: () => void
 }
 
 export const PlayerCard: React.FC<IPlayerCardProps> = ({
@@ -18,10 +19,11 @@ export const PlayerCard: React.FC<IPlayerCardProps> = ({
   card,
   isCurrentPlayerTurn,
   isOpponent = false,
+  onClick,
 }) => {
   const cardSize: TCardSize = isOpponent ? "small" : "large"
   return (
-    <Flex flexDirection={"column"}>
+    <Flex flexDirection={"column"} onClick={onClick}>
       <Text
         sx={{
           fontFamily: theme.fonts.antonio,

--- a/frontend/src/features/game/game-room.tsx
+++ b/frontend/src/features/game/game-room.tsx
@@ -4,14 +4,14 @@ import { Box, Flex, Text } from "rebass"
 import { CardEmptyState, Card, Button } from "src/components"
 import { useAppSelector } from "src/redux/utils"
 import { theme } from "src/theme"
-import { useGetMainPlayer } from "src/utils/helpers"
+import { useMainPlayer } from "src/utils/helpers"
 import { PlayerBlock } from "./player-block"
 import { CardSymbol } from "alacrity-shared"
 
 export const GameRoom: React.FC = () => {
   const players = useAppSelector((state) => state.currentGame?.players || [])
   const currentPlayerId = useAppSelector((state) => state.currentGame?.currentPlayerId)
-  const mainPlayer = useGetMainPlayer()
+  const mainPlayer = useMainPlayer()
 
   const isCurrentPlayerTurn = currentPlayerId === mainPlayer?.id
 

--- a/frontend/src/features/game/game-room.tsx
+++ b/frontend/src/features/game/game-room.tsx
@@ -1,23 +1,19 @@
 import React from "react"
 import { Box, Flex, Text } from "rebass"
-import { CardEmptyState } from "src/components/card-empty-state"
 
+import { CardEmptyState, Card, Button } from "src/components"
 import { useAppSelector } from "src/redux/utils"
 import { theme } from "src/theme"
-import { Card } from "../../components/card"
+import { useGetMainPlayer } from "src/utils/helpers"
 import { PlayerBlock } from "./player-block"
 import { CardSymbol } from "alacrity-shared"
-import { Button } from "src/components"
 
 export const GameRoom: React.FC = () => {
   const players = useAppSelector((state) => state.currentGame?.players || [])
   const currentPlayerId = useAppSelector((state) => state.currentGame?.currentPlayerId)
-  const playerId = useAppSelector((state) => state.playerId)
+  const mainPlayer = useGetMainPlayer()
 
-  const opponentPlayers = players.filter((player) => player.id !== playerId)
-  const player = players.find((player) => player.id === playerId)
-
-  const isCurrentPlayerTurn = currentPlayerId === player?.id
+  const isCurrentPlayerTurn = currentPlayerId === mainPlayer?.id
 
   return (
     <Box
@@ -38,12 +34,11 @@ export const GameRoom: React.FC = () => {
           minHeight: theme.styles.smallCard.containerCard.height,
         }}
       >
-        {opponentPlayers.map((opponentPlayer) => (
+        {players.map((player) => (
           <PlayerBlock
-            key={opponentPlayer.id}
-            player={opponentPlayer}
-            isOpponent
-            isCurrentPlayerTurn={currentPlayerId === opponentPlayer.id}
+            key={player.id}
+            player={player}
+            isCurrentPlayerTurn={currentPlayerId === player.id}
           />
         ))}
       </Flex>
@@ -58,7 +53,6 @@ export const GameRoom: React.FC = () => {
         />
         <CardEmptyState size={"medium"} />
       </Flex>
-      <PlayerBlock player={player} isCurrentPlayerTurn={isCurrentPlayerTurn} />
     </Box>
   )
 }

--- a/frontend/src/features/game/player-block.tsx
+++ b/frontend/src/features/game/player-block.tsx
@@ -28,7 +28,7 @@ export const PlayerBlock: React.FC<IPlayerBlockProps> = ({ player, isCurrentPlay
     isCurrentPlayerTurn,
   }
 
-  const handleCardClick = ({
+  const handleCardWon = ({
     playerCard,
     mainPlayer,
     wildCard,
@@ -59,7 +59,7 @@ export const PlayerBlock: React.FC<IPlayerBlockProps> = ({ player, isCurrentPlay
   return isOpponent ? (
     <PlayerCard
       {...sharedProps}
-      onClick={() => handleCardClick({ playerCard, mainPlayer, wildCard })}
+      onClick={() => handleCardWon({ playerCard, mainPlayer, wildCard })}
     />
   ) : (
     <Flex

--- a/frontend/src/features/game/player-block.tsx
+++ b/frontend/src/features/game/player-block.tsx
@@ -1,8 +1,10 @@
-import { IGamePlayer } from "alacrity-shared"
+import { FrontendWebsocketActions, IGamePlayer, IPlayingCard, IWildCard } from "alacrity-shared"
 import React from "react"
 import { Flex } from "rebass"
 import { PlayerCard, IPlayerCardProps } from "src/components"
+import { useAppSelector } from "src/redux/utils"
 import { useGetMainPlayer } from "src/utils/helpers"
+import { useWSContext } from "src/utils/websocket-context"
 
 interface IPlayerBlockProps {
   player: IGamePlayer
@@ -11,6 +13,8 @@ interface IPlayerBlockProps {
 
 export const PlayerBlock: React.FC<IPlayerBlockProps> = ({ player, isCurrentPlayerTurn }) => {
   const mainPlayer = useGetMainPlayer()
+  const { sendMessage } = useWSContext()
+  const wildCard = useAppSelector((state) => state.currentGame?.wildCard)
 
   const playPile = player.playPile
   const playerCard = playPile?.[playPile.length - 1] || null
@@ -24,8 +28,39 @@ export const PlayerBlock: React.FC<IPlayerBlockProps> = ({ player, isCurrentPlay
     isCurrentPlayerTurn,
   }
 
+  const handleCardClick = ({
+    playerCard,
+    mainPlayer,
+    wildCard,
+  }: {
+    playerCard: IPlayingCard | null
+    mainPlayer: IGamePlayer | undefined
+    wildCard: IWildCard | undefined
+  }) => {
+    const mainPlayerPile = mainPlayer?.playPile
+    const mainPlayerCard = mainPlayerPile?.[mainPlayerPile.length - 1] || null
+
+    const matchesWildCard = wildCard?.symbols.every(
+      (symbol) => symbol === mainPlayerCard?.symbol || symbol === playerCard?.symbol,
+    )
+
+    if (!playerCard) {
+      return
+    }
+
+    if (mainPlayerCard?.symbol === playerCard.symbol || matchesWildCard) {
+      sendMessage({
+        action: FrontendWebsocketActions.CardWon,
+        loserPlayerId: player.id,
+      })
+    }
+  }
+
   return isOpponent ? (
-    <PlayerCard {...sharedProps} />
+    <PlayerCard
+      {...sharedProps}
+      onClick={() => handleCardClick({ playerCard, mainPlayer, wildCard })}
+    />
   ) : (
     <Flex
       sx={{

--- a/frontend/src/features/game/player-block.tsx
+++ b/frontend/src/features/game/player-block.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { Flex } from "rebass"
 import { PlayerCard, IPlayerCardProps } from "src/components"
 import { useAppSelector } from "src/redux/utils"
-import { useGetMainPlayer } from "src/utils/helpers"
+import { useMainPlayer } from "src/utils/helpers"
 import { useWSContext } from "src/utils/websocket-context"
 
 interface IPlayerBlockProps {
@@ -12,7 +12,7 @@ interface IPlayerBlockProps {
 }
 
 export const PlayerBlock: React.FC<IPlayerBlockProps> = ({ player, isCurrentPlayerTurn }) => {
-  const mainPlayer = useGetMainPlayer()
+  const mainPlayer = useMainPlayer()
   const { sendMessage } = useWSContext()
   const wildCard = useAppSelector((state) => state.currentGame?.wildCard)
   const roomId = useAppSelector((state) => state.roomId)
@@ -20,7 +20,7 @@ export const PlayerBlock: React.FC<IPlayerBlockProps> = ({ player, isCurrentPlay
   const playPile = player.playPile
   const playerCard = playPile?.[playPile.length - 1] || null
 
-  const isOpponent = !(player?.id === mainPlayer?.id)
+  const isOpponent = player?.id !== mainPlayer?.id
 
   const sharedProps: IPlayerCardProps = {
     card: playerCard,

--- a/frontend/src/features/game/player-block.tsx
+++ b/frontend/src/features/game/player-block.tsx
@@ -15,6 +15,7 @@ export const PlayerBlock: React.FC<IPlayerBlockProps> = ({ player, isCurrentPlay
   const mainPlayer = useGetMainPlayer()
   const { sendMessage } = useWSContext()
   const wildCard = useAppSelector((state) => state.currentGame?.wildCard)
+  const roomId = useAppSelector((state) => state.roomId)
 
   const playPile = player.playPile
   const playerCard = playPile?.[playPile.length - 1] || null
@@ -51,6 +52,7 @@ export const PlayerBlock: React.FC<IPlayerBlockProps> = ({ player, isCurrentPlay
     if (mainPlayerCard?.symbol === playerCard.symbol || matchesWildCard) {
       sendMessage({
         action: FrontendWebsocketActions.CardWon,
+        roomId,
         loserPlayerId: player.id,
       })
     }

--- a/frontend/src/features/game/player-block.tsx
+++ b/frontend/src/features/game/player-block.tsx
@@ -1,30 +1,31 @@
 import { IGamePlayer } from "alacrity-shared"
 import React from "react"
 import { Flex } from "rebass"
-import { PlayerCard } from "src/components/player-card"
+import { PlayerCard, IPlayerCardProps } from "src/components"
+import { useGetMainPlayer } from "src/utils/helpers"
 
 interface IPlayerBlockProps {
-  player?: IGamePlayer
+  player: IGamePlayer
   isCurrentPlayerTurn: boolean
-  isOpponent?: boolean
 }
 
-export const PlayerBlock: React.FC<IPlayerBlockProps> = ({
-  player,
-  isOpponent,
-  isCurrentPlayerTurn,
-}) => {
-  const playPile = player?.playPile
-  const card = playPile ? playPile[playPile.length - 1] : null
-  const playerName = player?.name || ""
+export const PlayerBlock: React.FC<IPlayerBlockProps> = ({ player, isCurrentPlayerTurn }) => {
+  const mainPlayer = useGetMainPlayer()
+
+  const playPile = player.playPile
+  const playerCard = playPile?.[playPile.length - 1] || null
+
+  const isOpponent = !(player?.id === mainPlayer?.id)
+
+  const sharedProps: IPlayerCardProps = {
+    card: playerCard,
+    playerName: player.name,
+    isOpponent,
+    isCurrentPlayerTurn,
+  }
 
   return isOpponent ? (
-    <PlayerCard
-      card={card}
-      playerName={playerName}
-      isCurrentPlayerTurn={isCurrentPlayerTurn}
-      isOpponent
-    />
+    <PlayerCard {...sharedProps} />
   ) : (
     <Flex
       sx={{
@@ -34,7 +35,7 @@ export const PlayerBlock: React.FC<IPlayerBlockProps> = ({
         justifyContent: "center",
       }}
     >
-      <PlayerCard card={card} playerName={playerName} isCurrentPlayerTurn={isCurrentPlayerTurn} />
+      <PlayerCard {...sharedProps} />
     </Flex>
   )
 }

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -17,13 +17,13 @@ export const theme = {
       containerCard: { width: 242, height: 327 },
       innerCard: { width: 228, height: 307, borderRadius: 15 },
       symbol: { width: 75, height: 75, marginY: 50 },
-      fontSize: { back: 45, front: 45 },
+      fontSize: { back: 35, front: 35 },
     },
     mediumCard: {
       containerCard: { width: 180, height: 245 },
       innerCard: { width: 165, height: 230, borderRadius: 10 },
       symbol: { width: 30, height: 30, marginY: 30 },
-      fontSize: { back: 34, front: 34 },
+      fontSize: { back: 30, front: 30 },
     },
     smallCard: {
       containerCard: { width: 140, height: 185 },

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -1,1 +1,11 @@
+import { useAppSelector } from "src/redux/utils"
+
 export const getIsAdmin = () => !window.location.pathname.slice(1)
+
+export const useGetMainPlayer = () => {
+  const players = useAppSelector((state) => state.currentGame?.players || [])
+  const playerId = useAppSelector((state) => state.playerId)
+  const player = players.find((player) => player.id === playerId)
+
+  return player
+}

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -2,7 +2,7 @@ import { useAppSelector } from "src/redux/utils"
 
 export const getIsAdmin = () => !window.location.pathname.slice(1)
 
-export const useGetMainPlayer = () => {
+export const useMainPlayer = () => {
   const players = useAppSelector((state) => state.currentGame?.players || [])
   const playerId = useAppSelector((state) => state.playerId)
   const mainPlayer = players.find((player) => player.id === playerId)

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -5,7 +5,7 @@ export const getIsAdmin = () => !window.location.pathname.slice(1)
 export const useGetMainPlayer = () => {
   const players = useAppSelector((state) => state.currentGame?.players || [])
   const playerId = useAppSelector((state) => state.playerId)
-  const player = players.find((player) => player.id === playerId)
+  const mainPlayer = players.find((player) => player.id === playerId)
 
-  return player
+  return mainPlayer
 }

--- a/shared/package.json
+++ b/shared/package.json
@@ -7,7 +7,7 @@
   "type": "commonjs",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc"
+    "build": "rm -rf dist/* && tsc"
   },
   "peerDependencies": {
     "@types/node": "14.14.25",

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -116,6 +116,7 @@ export interface ICardDrawnEvent {
 
 export interface ICardWonEvent {
   action: FrontendWebsocketActions.CardWon
+  roomId: string
   loserPlayerId: string
 }
 


### PR DESCRIPTION
**changes**
- refactored game room and player block logic
- tweaked card font sizes to accommodate longer words
- handle card won logic

**demossss**
only send `card_won` event when:

opponent and main player card symbols match :

https://user-images.githubusercontent.com/52426595/162597115-3a3b85c4-96a1-4ec1-94fc-c8af0b9833eb.mov

opponent and main player card symbols match wild card symbols:

https://user-images.githubusercontent.com/52426595/162597172-f6713f3b-5e8a-46e8-b68d-dadd939ad42a.mov

works with multiple matching cards too:

https://user-images.githubusercontent.com/52426595/162597181-8a1dba95-4fbc-4e5f-b55a-cb3a1ab708d5.mov


