### PR TITLE
feat: reveal score and end game

### DIFF
--- a/backend/src/functions/onCardWon.ts
+++ b/backend/src/functions/onCardWon.ts
@@ -51,15 +51,15 @@ export const handler = async (event: APIGatewayEvent) => {
 
   console.log("sending event", BackendWebsocketActions.GameUpdated)
   await Promise.all(
-    updatedPlayers.map((player) => {
+    updatedPlayers.map((player) =>
       ws.sendMessage<IGameUpdatedEvent>({
         connectionId: player.id,
         body: {
           action: BackendWebsocketActions.GameUpdated,
           currentGame: serializedUpdatedGame,
         },
-      })
-    }),
+      }),
+    ),
   )
 
   return { statusCode: 200 }

--- a/backend/src/functions/onGameEnded.ts
+++ b/backend/src/functions/onGameEnded.ts
@@ -1,0 +1,71 @@
+import {
+  BackendWebsocketActions,
+  IGameScoreUpdatedEvent,
+  IGameStartedEvent,
+  IGameUpdatedEvent,
+  IPlayerScoreInfo,
+} from "alacrity-shared"
+
+import { database, ws } from "@services"
+import { getGame, getSerializedCurrentGame } from "@utils"
+import { APIGatewayEvent } from "aws-lambda"
+
+export const handler = async (event: APIGatewayEvent) => {
+  const {
+    requestContext: { routeKey },
+  } = event
+  const { roomId }: IGameStartedEvent = JSON.parse(event.body)
+
+  console.log("onGameStarted: recieved route key:", routeKey)
+
+  const room = await database.room.get({ roomId })
+  const currentGame = getGame(room)
+
+  const scores = currentGame.players
+    .map(
+      (player): IPlayerScoreInfo => ({
+        id: player.id,
+        name: player.name,
+        score: player.winningPile.length,
+      }),
+    )
+    .sort((a, b) => b.score - a.score)
+
+  await Promise.all(
+    currentGame.players.map((player) => {
+      ws.sendMessage<IGameScoreUpdatedEvent>({
+        connectionId: player.id,
+        body: {
+          action: BackendWebsocketActions.GameScoreUpdated,
+          scores,
+        },
+      })
+    }),
+  )
+
+  if (currentGame.status !== "ended") {
+    await database.room.updateGame({
+      roomId,
+      game: {
+        ...currentGame,
+        status: "ended",
+      },
+    })
+  }
+
+  const updatedGame = await getSerializedCurrentGame({ roomId })
+
+  await Promise.all(
+    currentGame.players.map((player) => {
+      ws.sendMessage<IGameUpdatedEvent>({
+        connectionId: player.id,
+        body: {
+          action: BackendWebsocketActions.GameUpdated,
+          currentGame: updatedGame,
+        },
+      })
+    }),
+  )
+
+  return { statusCode: 200 }
+}

--- a/backend/src/functions/onGameEnded.ts
+++ b/backend/src/functions/onGameEnded.ts
@@ -32,15 +32,15 @@ export const handler = async (event: APIGatewayEvent) => {
     .sort((a, b) => b.score - a.score)
 
   await Promise.all(
-    currentGame.players.map((player) => {
+    currentGame.players.map((player) =>
       ws.sendMessage<IGameScoreUpdatedEvent>({
         connectionId: player.id,
         body: {
           action: BackendWebsocketActions.GameScoreUpdated,
           scores,
         },
-      })
-    }),
+      }),
+    ),
   )
 
   if (currentGame.status !== "ended") {
@@ -56,15 +56,15 @@ export const handler = async (event: APIGatewayEvent) => {
   const updatedGame = await getSerializedCurrentGame({ roomId })
 
   await Promise.all(
-    currentGame.players.map((player) => {
+    currentGame.players.map((player) =>
       ws.sendMessage<IGameUpdatedEvent>({
         connectionId: player.id,
         body: {
           action: BackendWebsocketActions.GameUpdated,
           currentGame: updatedGame,
         },
-      })
-    }),
+      }),
+    ),
   )
 
   return { statusCode: 200 }

--- a/backend/src/functions/onGameStarted.ts
+++ b/backend/src/functions/onGameStarted.ts
@@ -53,7 +53,6 @@ export const handler = async (event: APIGatewayEvent) => {
           totalDrawCardsRemaining: newGame.drawPile.length,
           wildCard: null,
           currentPlayerId: newGame.currentPlayerId,
-          status: newGame.status,
         },
       },
     }),

--- a/backend/src/resources/functions.ts
+++ b/backend/src/resources/functions.ts
@@ -59,15 +59,16 @@ export const functions: Serverless["functions"] = {
   //     },
   //   ],
   // },
-  // onGameEnded: {
-  //   events: [
-  //     {
-  //       websocket: {
-  //         route: FrontendWebsocketActions.GameEnded,
-  //       },
-  //     },
-  //   ],
-  // },
+  onGameEnded: {
+    handler: `src/functions/onGameEnded.handler`,
+    events: [
+      {
+        websocket: {
+          route: "game_ended",
+        },
+      },
+    ],
+  },
   onDisconnect: {
     handler: `src/functions/onDisconnect.handler`,
     events: [

--- a/backend/src/utils/serializer.ts
+++ b/backend/src/utils/serializer.ts
@@ -20,6 +20,11 @@ export const getSerializedCurrentGame = async ({ roomId }: { roomId: string }): 
   try {
     const room = await database.room.get({ roomId })
     const game = getGame(room)
+
+    if (!game || game.status === "ended") {
+      return null
+    }
+
     const players: IPlayer[] = getPlayers(room).map((player) => {
       const gamePlayer = game?.players.find((gamePlayer) => player.id === gamePlayer.id)
 
@@ -31,16 +36,13 @@ export const getSerializedCurrentGame = async ({ roomId }: { roomId: string }): 
       }
     })
 
-    return game
-      ? {
-          id: game.id,
-          players,
-          totalDrawCardsRemaining: game.drawPile.length,
-          wildCard: game.wildCardPile[game.wildCardPile.length - 1],
-          currentPlayerId: game.currentPlayerId,
-          status: game.status,
-        }
-      : null
+    return {
+      id: game.id,
+      players,
+      totalDrawCardsRemaining: game.drawPile.length,
+      wildCard: game.wildCardPile[game.wildCardPile.length - 1],
+      currentPlayerId: game.currentPlayerId,
+    }
   } catch (e) {
     return null
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,11 +3,13 @@ import { WaitingRoom, GameRoom } from "./features"
 import { useAppSelector } from "./redux/utils"
 import { LoadingTitleScreen } from "./components/loading-title-screen"
 import { ErrorScreen } from "./features/error/error-screen"
+import { ScoreBoard } from "./features/score-board"
 
 export const App: React.FC = () => {
   const currentGame = useAppSelector((state) => state?.currentGame)
   const roomStatus = useAppSelector((state) => state.roomStatus)
   const playerId = useAppSelector((state) => state.playerId)
+  const gameScore = useAppSelector((state) => state.gameScore)
 
   if (roomStatus !== "ready") {
     return <ErrorScreen />
@@ -15,6 +17,10 @@ export const App: React.FC = () => {
 
   if (!playerId) {
     return <LoadingTitleScreen />
+  }
+
+  if (gameScore && gameScore.length) {
+    return <ScoreBoard />
   }
 
   return !currentGame ? <WaitingRoom /> : <GameRoom />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,7 @@ import { LoadingTitleScreen } from "./components/loading-title-screen"
 import { ErrorScreen } from "./features/error/error-screen"
 
 export const App: React.FC = () => {
-  const gameStatus = useAppSelector((state) => state?.currentGame?.status)
+  const currentGame = useAppSelector((state) => state?.currentGame)
   const roomStatus = useAppSelector((state) => state.roomStatus)
   const playerId = useAppSelector((state) => state.playerId)
 
@@ -16,5 +16,6 @@ export const App: React.FC = () => {
   if (!playerId) {
     return <LoadingTitleScreen />
   }
-  return gameStatus !== "started" ? <WaitingRoom /> : <GameRoom />
+
+  return !currentGame ? <WaitingRoom /> : <GameRoom />
 }

--- a/frontend/src/features/game/game-room.tsx
+++ b/frontend/src/features/game/game-room.tsx
@@ -6,8 +6,9 @@ import { useAppSelector } from "src/redux/utils"
 import { theme } from "src/theme"
 import { Card } from "../../components/card"
 import { PlayerBlock } from "./player-block"
-import { CardSymbol } from "alacrity-shared"
+import { CardSymbol, FrontendWebsocketActions } from "alacrity-shared"
 import { Button } from "src/components"
+import { useWSContext } from "src/utils/websocket-context"
 
 export const GameRoom: React.FC = () => {
   const players = useAppSelector((state) => state.currentGame?.players || [])
@@ -18,6 +19,19 @@ export const GameRoom: React.FC = () => {
   const player = players.find((player) => player.id === playerId)
 
   const isCurrentPlayerTurn = currentPlayerId === player?.id
+
+  const { sendMessage } = useWSContext()
+  const roomId = useAppSelector((state) => state.roomId)
+  const totalDrawCardsRemaining = useAppSelector(
+    (state) => state.currentGame?.totalDrawCardsRemaining,
+  )
+
+  if (!totalDrawCardsRemaining) {
+    sendMessage({
+      action: FrontendWebsocketActions.GameEnded,
+      roomId,
+    })
+  }
 
   return (
     <Box

--- a/frontend/src/features/game/game-room.tsx
+++ b/frontend/src/features/game/game-room.tsx
@@ -1,10 +1,10 @@
-import React from "react"
+import React, { useEffect } from "react"
 import { Box, Flex, Text } from "rebass"
 
 import { CardEmptyState, Card, Button } from "src/components"
 import { useAppSelector } from "src/redux/utils"
 import { theme } from "src/theme"
-import { useMainPlayer } from "src/utils/helpers"
+import { getIsAdmin, useMainPlayer } from "src/utils/helpers"
 import { PlayerBlock } from "./player-block"
 import { CardSymbol, FrontendWebsocketActions } from "alacrity-shared"
 import { useWSContext } from "src/utils/websocket-context"
@@ -22,12 +22,14 @@ export const GameRoom: React.FC = () => {
     (state) => state.currentGame?.totalDrawCardsRemaining,
   )
 
-  if (!totalDrawCardsRemaining) {
-    sendMessage({
-      action: FrontendWebsocketActions.GameEnded,
-      roomId,
-    })
-  }
+  useEffect(() => {
+    if (getIsAdmin() && !totalDrawCardsRemaining) {
+      sendMessage({
+        action: FrontendWebsocketActions.GameEnded,
+        roomId,
+      })
+    }
+  }, [roomId, totalDrawCardsRemaining, sendMessage])
 
   return (
     <Box

--- a/frontend/src/features/score-board.tsx
+++ b/frontend/src/features/score-board.tsx
@@ -1,0 +1,77 @@
+import React from "react"
+import { useDispatch } from "react-redux"
+import { Box, Flex, Text } from "rebass"
+import { Button } from "src/components"
+import { actions } from "src/redux/slice"
+import { useAppSelector } from "src/redux/utils"
+import { theme } from "src/theme"
+
+export const ScoreBoard: React.FC = () => {
+  const score = useAppSelector((state) => state.gameScore)
+  const playerId = useAppSelector((state) => state.playerId)
+  const dispatch = useDispatch()
+  const winner = score?.[0]
+
+  const handleBackToRoom = () => {
+    dispatch(actions.setGameScore(null))
+  }
+
+  return (
+    <Flex
+      sx={{
+        backgroundColor: theme.colors.navy,
+        height: "100vh",
+        width: "100vw",
+        justifyContent: "center",
+        alignItems: "center",
+        color: theme.colors.white,
+        flexDirection: "column",
+      }}
+    >
+      <Text
+        sx={{
+          fontSize: 60,
+          fontFamily: theme.fonts.antonio,
+        }}
+      >{`WINNER: ${winner?.name.toUpperCase()} 🎉`}</Text>
+      <Box
+        sx={{
+          marginTop: 40,
+          marginBottom: 60,
+        }}
+      >
+        {score?.map((playerScoreInfo, idx) => (
+          <Flex
+            key={idx}
+            sx={{
+              marginTop: idx ? 10 : 0,
+              minWidth: "350px",
+              justifyContent: "space-between",
+              color: playerScoreInfo.id === playerId ? theme.colors.red : theme.colors.white,
+            }}
+          >
+            <Text
+              sx={{
+                fontSize: 20,
+                fontFamily: theme.fonts.antonio,
+              }}
+            >
+              {playerScoreInfo.name.toUpperCase()}
+            </Text>
+            <Text
+              sx={{
+                fontSize: 20,
+                fontFamily: theme.fonts.antonio,
+              }}
+            >
+              {playerScoreInfo.score}
+            </Text>
+          </Flex>
+        ))}
+      </Box>
+      <Button sx={{ fontSize: 20 }} onClick={handleBackToRoom}>
+        BACK TO ROOM
+      </Button>
+    </Flex>
+  )
+}

--- a/frontend/src/redux/slice.ts
+++ b/frontend/src/redux/slice.ts
@@ -1,5 +1,5 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit"
-import { IPlayer, IGame } from "alacrity-shared"
+import { IPlayer, IGame, IPlayerScoreInfo } from "alacrity-shared"
 
 export type TRoomStatus = "ready" | "not_found" | "admin_disconnected"
 
@@ -7,6 +7,7 @@ export interface IState {
   playerId: string
   playerPool: IPlayer[]
   currentGame: IGame | null
+  gameScore: IPlayerScoreInfo[] | null
   roomId: string
   roomStatus: TRoomStatus
 }
@@ -15,6 +16,7 @@ const initialState: IState = {
   playerId: "",
   playerPool: [],
   currentGame: null,
+  gameScore: null,
   roomId: "",
   roomStatus: "ready",
 }
@@ -42,6 +44,10 @@ export const { actions, reducer } = createSlice({
     setRoomStatus: (state, action: PayloadAction<TRoomStatus>) => ({
       ...state,
       roomStatus: action.payload,
+    }),
+    setGameScore: (state, action: PayloadAction<IPlayerScoreInfo[] | null>) => ({
+      ...state,
+      gameScore: action.payload,
     }),
   },
 })

--- a/frontend/src/utils/websocket-context.tsx
+++ b/frontend/src/utils/websocket-context.tsx
@@ -59,6 +59,9 @@ export const WSContextProvider: React.FC = ({ children }) => {
           case BackendWebsocketActions.AdminDisconnected:
             dispatch(actions.setRoomStatus("admin_disconnected"))
             break
+          case BackendWebsocketActions.GameScoreUpdated:
+            dispatch(actions.setGameScore(data.scores))
+            break
         }
       }
 

--- a/shared/package.json
+++ b/shared/package.json
@@ -7,7 +7,7 @@
   "type": "commonjs",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc"
+    "build": "rm -rf dist/* && tsc"
   },
   "peerDependencies": {
     "@types/node": "14.14.25",

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -37,7 +37,12 @@ export interface IGame {
   totalDrawCardsRemaining: number
   wildCard: IWildCard
   currentPlayerId: string
-  status: "started" | "ended"
+}
+
+export interface IPlayerScoreInfo {
+  id: string
+  name: string
+  score: number
 }
 
 // Websockets
@@ -49,6 +54,7 @@ export enum BackendWebsocketActions {
   RoomNotFound = "room_not_found",
   AdminDisconnected = "admin_disconnected",
   AddPlayerFailed = "add_player_failed",
+  GameScoreUpdated = "game_score_updated",
 }
 
 export enum FrontendWebsocketActions {
@@ -84,12 +90,18 @@ export interface IGameUpdatedEvent {
   currentGame: IGame | null
 }
 
+export interface IGameScoreUpdatedEvent {
+  action: BackendWebsocketActions.GameScoreUpdated
+  scores: IPlayerScoreInfo[]
+}
+
 export type TBackendWebsocketEvent =
   | IPlayerIdSetEvent
   | IPlayerPoolUpdatedEvent
   | IGameUpdatedEvent
   | IAdminDisconnectedEvent
   | IRoomNotFoundEvent
+  | IGameScoreUpdatedEvent
 
 // Frontend events
 
@@ -121,6 +133,7 @@ export interface ICardWonEvent {
 
 export interface IGameEndedEvent {
   action: FrontendWebsocketActions.GameEnded
+  roomId: string
 }
 
 export type TFrontendWebsocketEvent =
@@ -130,4 +143,3 @@ export type TFrontendWebsocketEvent =
   | ICardDrawnEvent
   | ICardWonEvent
   | IGameEndedEvent
-  | IGameStartedEvent


### PR DESCRIPTION
**what's happening:**
- when no `totalDrawCardsRemaining`, FE sends `game_ended` WS event
- in the BE, `onGameEnded` handler receives event and does the following:
  - collects the players scores and sorts by most cards won
  - sends this to FE as `game_score_updated` event
  - updates current game status to ended
  - sends `game_updated_event` with `currentGame = null`
- new state `gameScore` in FE: populated with the score upon receiving `game_score_updated` event
- this triggers `ScoreBoard` component to be rendered, which looks like this:
![Screen Shot 2022-04-10 at 1 19 35 AM](https://user-images.githubusercontent.com/52426595/163079044-590a4b31-c2f0-411c-ac02-74c88f9c28a7.png)
- clicking on back to room button clears this score state, and will render `WaitingRoom` component since `currentGame` is now null.

**notable changes:**
- removed `gameStatus` from FE – i feel like it overcomplicates the FE. the game model still has the current game status tho, which is set to `ended` on game ended event.

