### PR TITLE
fix styling on card so that text fits

### DIFF
--- a/frontend/src/components/card.tsx
+++ b/frontend/src/components/card.tsx
@@ -85,13 +85,20 @@ export const Card: React.FC<ICardProps> = ({
       }}
     >
       {side === "front" ? (
-        <>
+        <Flex
+          sx={{
+            flexDirection: "column",
+            justifyContent: "space-around",
+            height: "100%",
+            alignItems: "center",
+          }}
+        >
           <CardText fontSize={fontSize.front}>{text}</CardText>
-          <Image sx={{ ...symbolStyles, fill: "pink" }} src={symbolToImg[symbol]} />
+          <Image sx={{ ...symbolStyles }} src={symbolToImg[symbol]} />
           <CardText fontSize={fontSize.front} upsideDown>
             {text}
           </CardText>
-        </>
+        </Flex>
       ) : (
         <Flex
           sx={{

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -25,7 +25,6 @@ export const theme = {
       symbol: {
         width: scaleSize(75),
         height: scaleSize(75),
-        marginY: scaleSize(50),
       },
       fontSize: { back: scaleSize(35), front: scaleSize(35) },
     },
@@ -39,7 +38,6 @@ export const theme = {
       symbol: {
         width: scaleSize(30),
         height: scaleSize(30),
-        marginY: scaleSize(30),
       },
       fontSize: { back: scaleSize(30), front: scaleSize(30) },
     },
@@ -53,7 +51,6 @@ export const theme = {
       symbol: {
         width: scaleSize(30),
         height: scaleSize(30),
-        marginY: scaleSize(30),
       },
       fontSize: { back: scaleSize(26), front: scaleSize(20) },
     },


### PR DESCRIPTION
**Changes**
- replace `Limited Edition Starbucks Frappaccino` with `Starbucks Frappaccino` in s3
- remove marginY on symbol and use justifyContent "space-between" instead 

longest phrase now is:

<img width="1440" alt="Screen Shot 2022-04-16 at 5 11 27 PM" src="https://user-images.githubusercontent.com/38989901/163691663-c0cb14cd-eb7e-4b30-babf-d6d7c673dae7.png">

